### PR TITLE
Feature/add glue version

### DIFF
--- a/glue-job.cfndsl.rb
+++ b/glue-job.cfndsl.rb
@@ -21,6 +21,7 @@ CloudFormation do
   default_max_concurrent_runs = glue_job_defaults.fetch('max_concurrent_runs', nil)
   default_max_retries= glue_job_defaults.fetch('max_retries', nil)
   default_allocated_capacity = glue_job_defaults.fetch('allocated_capacity', nil)
+  default_glue_version = glue_job_defaults.fetch('glue_version', nil)
   default_pylibs = glue_job_defaults.fetch('pylibs', nil)
 
   glue_jobs = external_parameters.fetch(:glue_jobs, {})
@@ -37,11 +38,16 @@ CloudFormation do
     max_retries = job.fetch('max_retries', default_max_retries)
     allocated_capacity = job.fetch('allocated_capacity', default_allocated_capacity)
     max_concurrent_runs = job.fetch('max_concurrent_runs', default_max_concurrent_runs)
+    glue_version = job.fetch('glue_version', default_glue_version)
 
     Glue_Job(job_resource_name) do
       Name FnSub("${EnvironmentName}-#{job_name}")
       Description FnSub(description)
       Role Ref(:GlueServiceRole)
+
+      unless glue_version.nil?
+        GlueVersion glue_version
+      end
 
       unless max_retries.nil?
         MaxRetries max_retries

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -49,6 +49,10 @@ describe 'compiled component glue-job' do
           expect(resource["Properties"]["Role"]).to eq({"Ref"=>"GlueServiceRole"})
       end
       
+      it "to have property GlueVersion" do
+          expect(resource["Properties"]["GlueVersion"]).to eq(3)
+      end
+      
       it "to have property MaxRetries" do
           expect(resource["Properties"]["MaxRetries"]).to eq(0)
       end
@@ -100,6 +104,84 @@ describe 'compiled component glue-job' do
       
       it "to have property Actions" do
           expect(resource["Properties"]["Actions"]).to eq([{"JobName"=>{"Fn::Sub"=>"${EnvironmentName}-job_name"}}])
+      end
+      
+    end
+    
+    context "Overrideglueversionjob" do
+      let(:resource) { template["Resources"]["Overrideglueversionjob"] }
+
+      it "is of type AWS::Glue::Job" do
+          expect(resource["Type"]).to eq("AWS::Glue::Job")
+      end
+      
+      it "to have property Name" do
+          expect(resource["Properties"]["Name"]).to eq({"Fn::Sub"=>"${EnvironmentName}-override_glue_version_job"})
+      end
+      
+      it "to have property Description" do
+          expect(resource["Properties"]["Description"]).to eq({"Fn::Sub"=>"example job"})
+      end
+      
+      it "to have property Role" do
+          expect(resource["Properties"]["Role"]).to eq({"Ref"=>"GlueServiceRole"})
+      end
+      
+      it "to have property GlueVersion" do
+          expect(resource["Properties"]["GlueVersion"]).to eq(4)
+      end
+      
+      it "to have property MaxRetries" do
+          expect(resource["Properties"]["MaxRetries"]).to eq(0)
+      end
+      
+      it "to have property AllocatedCapacity" do
+          expect(resource["Properties"]["AllocatedCapacity"]).to eq(2)
+      end
+      
+      it "to have property ExecutionProperty" do
+          expect(resource["Properties"]["ExecutionProperty"]).to eq({"MaxConcurrentRuns"=>1})
+      end
+      
+      it "to have property Connections" do
+          expect(resource["Properties"]["Connections"]).to eq({"Connections"=>[{"Fn::Sub"=>"GlueConnection"}]})
+      end
+      
+      it "to have property DefaultArguments" do
+          expect(resource["Properties"]["DefaultArguments"]).to eq({"--extra-py-files"=>{"Fn::Sub"=>"s3://bucket-name/pylibs.zip"}})
+      end
+      
+      it "to have property Command" do
+          expect(resource["Properties"]["Command"]).to eq({"Name"=>"main", "ScriptLocation"=>{"Fn::Sub"=>"s3://bucket-name/scripts/main.py"}})
+      end
+      
+    end
+    
+    context "OverrideglueversionjobTrigger" do
+      let(:resource) { template["Resources"]["OverrideglueversionjobTrigger"] }
+
+      it "is of type AWS::Glue::Trigger" do
+          expect(resource["Type"]).to eq("AWS::Glue::Trigger")
+      end
+      
+      it "to have property Name" do
+          expect(resource["Properties"]["Name"]).to eq({"Fn::Sub"=>"${EnvironmentName}-override_glue_version_job-trigger"})
+      end
+      
+      it "to have property Type" do
+          expect(resource["Properties"]["Type"]).to eq("SCHEDULED")
+      end
+      
+      it "to have property Description" do
+          expect(resource["Properties"]["Description"]).to eq("example job")
+      end
+      
+      it "to have property Schedule" do
+          expect(resource["Properties"]["Schedule"]).to eq("cron(01 19 * * ? *)")
+      end
+      
+      it "to have property Actions" do
+          expect(resource["Properties"]["Actions"]).to eq([{"JobName"=>{"Fn::Sub"=>"${EnvironmentName}-override_glue_version_job"}}])
       end
       
     end

--- a/tests/job.test.yaml
+++ b/tests/job.test.yaml
@@ -9,6 +9,7 @@ test_parameters:
 glue_job_defaults:
   max_concurrent_runs: 1
   max_retries: 0
+  glue_version: 3
   allocated_capacity: 5
   pylibs: s3://bucket-name/pylibs.zip
 
@@ -22,6 +23,20 @@ glue_jobs:
   job_name:
     description: example job
     allocated_capacity: 2
+    default_args:
+      --target-database: dbname
+      --target-schema: dbschema
+      --s3-input-path: s3://bucket-name/data
+    connections:
+    - GlueConnection
+    command:
+      name: main
+      script: s3://bucket-name/scripts/main.py
+    schedule: cron(01 19 * * ? *)
+  override_glue_version_job:
+    description: example job
+    allocated_capacity: 2
+    glue_version: 4
     default_args:
       --target-database: dbname
       --target-schema: dbschema


### PR DESCRIPTION
Add parameter to specify glue version, currently it defaults to 0.9 if not set which is no longer supported past June 01.
```
GlueVersion

    Glue version determines the versions of Apache Spark and Python that AWS Glue supports. The Python version indicates the version supported for jobs of type Spark.

    Jobs that are created without specifying a Glue version default to Glue 0.9.
```
<img width="669" alt="Screen Shot 2023-05-25 at 4 25 40 pm" src="https://github.com/theonestack/hl-component-glue-job/assets/64295670/84433044-f5a8-4668-b2d4-c4f0bbb78625">
