### PR TITLE
Feature/fix default args

### DIFF
--- a/glue-job.cfndsl.rb
+++ b/glue-job.cfndsl.rb
@@ -30,7 +30,7 @@ CloudFormation do
     job_resource_name = job_name.capitalize.gsub(/[^0-9A-Za-z]/, '')
 
     default_args = glue_job_default_args.dup
-    default_args.merge!(job.fetch(:default_args, {}))
+    default_args.merge!(job.fetch("default_args", {}))
 
     pylibs = job.fetch('pylibs', default_pylibs)
     default_args[:"--extra-py-files"] = pylibs unless pylibs.nil?

--- a/glue-job.cfndsl.rb
+++ b/glue-job.cfndsl.rb
@@ -30,7 +30,7 @@ CloudFormation do
     job_resource_name = job_name.capitalize.gsub(/[^0-9A-Za-z]/, '')
 
     default_args = glue_job_default_args.dup
-    default_args.merge!(external_parameters.fetch(:default_args, {}))
+    default_args.merge!(job.fetch(:default_args, {}))
 
     pylibs = job.fetch('pylibs', default_pylibs)
     default_args[:"--extra-py-files"] = pylibs unless pylibs.nil?

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -70,7 +70,7 @@ describe 'compiled component glue-job' do
       end
       
       it "to have property DefaultArguments" do
-          expect(resource["Properties"]["DefaultArguments"]).to eq({"--extra-py-files"=>{"Fn::Sub"=>"s3://bucket-name/pylibs.zip"}})
+          expect(resource["Properties"]["DefaultArguments"]).to eq({"--target-database"=>{"Fn::Sub"=>"dbname"}, "--target-schema"=>{"Fn::Sub"=>"dbschema"}, "--s3-input-path"=>{"Fn::Sub"=>"s3://bucket-name/data"}, "--extra-py-files"=>{"Fn::Sub"=>"s3://bucket-name/pylibs.zip"}})
       end
       
       it "to have property Command" do
@@ -148,7 +148,7 @@ describe 'compiled component glue-job' do
       end
       
       it "to have property DefaultArguments" do
-          expect(resource["Properties"]["DefaultArguments"]).to eq({"--extra-py-files"=>{"Fn::Sub"=>"s3://bucket-name/pylibs.zip"}})
+          expect(resource["Properties"]["DefaultArguments"]).to eq({"--target-database"=>{"Fn::Sub"=>"dbname"}, "--target-schema"=>{"Fn::Sub"=>"dbschema"}, "--s3-input-path"=>{"Fn::Sub"=>"s3://bucket-name/data"}, "--extra-py-files"=>{"Fn::Sub"=>"s3://bucket-name/pylibs.zip"}})
       end
       
       it "to have property Command" do


### PR DESCRIPTION
Fixed issue when adding default args from nested glue configs by updating the reference to fetch from each individual job.

Default args are now populated per glue job as expected.